### PR TITLE
Update pip source for python 2.7

### DIFF
--- a/tensorflow_serving/tools/docker/Dockerfile.devel
+++ b/tensorflow_serving/tools/docker/Dockerfile.devel
@@ -46,7 +46,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-RUN curl -fSsL -O https://bootstrap.pypa.io/get-pip.py && \
+RUN curl -fSsL -O https://bootstrap.pypa.io/pip/2.7/get-pip.py && \
     python get-pip.py && \
     rm get-pip.py
 


### PR DESCRIPTION
pip 21.0 dropped support for Python 2 and 3.5 (https://pip.pypa.io/en/stable/news/#v21-0).

Use Please use https://bootstrap.pypa.io/pip/2.7/get-pip.py instead.