### PR TITLE
Update pip source 

### DIFF
--- a/tensorflow_serving/tools/docker/Dockerfile.devel-gpu
+++ b/tensorflow_serving/tools/docker/Dockerfile.devel-gpu
@@ -77,7 +77,7 @@ RUN apt-get update && \
     rm /usr/lib/x86_64-linux-gnu/libnvcaffe_parser* && \
     rm /usr/lib/x86_64-linux-gnu/libnvparsers*
 
-RUN curl -fSsL -O https://bootstrap.pypa.io/get-pip.py && \
+RUN curl -fSsL -O https://bootstrap.pypa.io/pip/2.7/get-pip.py && \
     python get-pip.py && \
     rm get-pip.py
 


### PR DESCRIPTION
pip 21.0 dropped support for Python 2 and 3.5 (https://pip.pypa.io/en/stable/news/#v21-0)

Use https://bootstrap.pypa.io/pip/2.7/get-pip.py instead.